### PR TITLE
SA-1585 Handle the HLS persistent connection case where we have a tra…

### DIFF
--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -1430,7 +1430,7 @@ static int read_data(void *opaque, uint8_t *buf, int buf_size)
     URLContext* urlc = NULL;
 
     // keep reference of mpegts parser callback mechanism
-    if(v->input) {
+    if(v->input && (!c->http_persistent || !v->input_read_done)) {
         interal = (struct AVIOInternal*)v->input->opaque;
         urlc = (URLContext*)interal->h;
         struct segment *seg = current_segment(v);

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -1567,7 +1567,7 @@ reload:
         }
 
         // replace mpegts parser callback mechanism
-        if(interal && urlc && v->input) {
+        if(interal && urlc && v->input && (!c->http_persistent || !v->input_read_done))  {
             interal = (struct AVIOInternal*)v->input->opaque;
             urlc = (URLContext*)interal->h;
             urlc->mpegts_parser_injection = v->mpegts_parser_input_backup;


### PR DESCRIPTION
check properly whether we have a transport we can read from.  Requires:
- a non-null transport
- and either:
    - non-peristent http connections (in which case a non-null transport is a valid transport)
    - the input_read_done flag = false meaning there's more to read

looks like when persistent connections were introduced they missed this spot to add the check