### PR TITLE
fix memory corruption issue

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1381,7 +1381,7 @@ static int parse_manifest(AVFormatContext *s, const char *url, AVIOContext *in)
 cleanup:
         /*free the document */
         xmlFreeDoc(doc);
-        xmlCleanupParser();
+        /* xmlCleanupParser(); Removed since it causes memory corruption in multithreaded environments */
         xmlFreeNode(mpd_baseurl_node);
     }
 


### PR DESCRIPTION
The xmlCleanupParser() call I've removed was causing memory corruption errors.  The documentation for that function says:
"This function name is somewhat misleading. It does not clean up parser state, it cleans up memory allocated by the library itself. It is a cleanup function for the XML library. It tries to reclaim all related global memory allocated for the library processing. It doesn't deallocate any document related memory. One should call xmlCleanupParser() only when the process has finished using the library and all XML/HTML documents built with it. See also xmlInitParser() which has the opposite function of preparing the library for operations. WARNING: if your application is multithreaded or has plugin support calling this may crash the application if another thread or a plugin is still using libxml2. It's sometimes very hard to guess if libxml2 is in use in the application, some libraries or plugins may use it without notice. In case of doubt abstain from calling this function or do it just before calling exit() to avoid leak reports from valgrind !"
We use libxml2 (via ffmpeg) in a multithreaded environment and we end up calling xmlCleanupParser while other threads are still parsing.  Removing this call solves the issue.  We will have a small (200 byte) memory leak - which we can perhaps address elsewhere.